### PR TITLE
DateRange mereology/lattice logic

### DIFF
--- a/tests/test_range.py
+++ b/tests/test_range.py
@@ -2,10 +2,10 @@
 Unit-tests for DateRange.
 """
 
+import unittest
 import math
 import pickle
 import random
-import unittest
 
 from yyyymmdd import Date, DateRange
 
@@ -164,16 +164,14 @@ class DateRangeTest(unittest.TestCase):
             d1 = DateRange.DATE_TYPE.fromordinal(random.randint(0, 1000000))
             d2 = d1 + random.randint(1, 100)
             dr = DateRange(d1, d2)  # non-empty
-            self.assertTrue(DateRange.empty() < dr)
-            self.assertTrue(DateRange.empty() <= dr)
-            self.assertFalse(dr < dr)
-            self.assertFalse(dr > dr)
+            self.assertTrue(DateRange.empty().is_proper_part(dr))
+            self.assertTrue(DateRange.empty().is_part(dr))
+            self.assertFalse(dr.is_proper_part(dr))
             self.assertTrue(dr.overlaps(dr))
-            self.assertTrue(dr <= dr)
-            self.assertTrue(dr >= dr)
+            self.assertTrue(dr.is_part(dr))
             self.assertTrue(dr.underlaps(dr))
             self.assertTrue(dr | dr == dr)
-            self.assertTrue((dr - dr) == [DateRange.empty()])
+            self.assertTrue((dr - dr) == [])
 
         self.assertFalse(DateRange.empty().overlaps(DateRange.empty()))
 
@@ -189,20 +187,24 @@ class DateRangeTest(unittest.TestCase):
             )
         )
         self.assertTrue(
-            DateRange.from_string("20220103:20220106")
-            < DateRange.from_string("20220103:20220110")
+            DateRange.from_string("20220103:20220106").is_proper_part(
+                DateRange.from_string("20220103:20220110")
+            )
         )
         self.assertTrue(
-            DateRange.from_string("20220103:20220106")
-            <= DateRange.from_string("20220103:20220110")
+            DateRange.from_string("20220103:20220106").is_part(
+                DateRange.from_string("20220103:20220110")
+            )
         )
         self.assertFalse(
-            DateRange.from_string("20220103:20220106")
-            > DateRange.from_string("20220103:20220110")
+            DateRange.from_string("20220103:20220110").is_proper_part(
+                DateRange.from_string("20220103:20220106")
+            )
         )
         self.assertFalse(
-            DateRange.from_string("20220103:20220106")
-            >= DateRange.from_string("20220103:20220110")
+            DateRange.from_string("20220103:20220110").is_part(
+                DateRange.from_string("20220103:20220106")
+            )
         )
         self.assertTrue(
             DateRange.from_string("20220102:20220106").overlaps(
@@ -215,20 +217,24 @@ class DateRangeTest(unittest.TestCase):
             )
         )
         self.assertFalse(
-            DateRange.from_string("20220102:20220106")
-            < DateRange.from_string("20220103:20220110")
+            DateRange.from_string("20220102:20220106").is_proper_part(
+                DateRange.from_string("20220103:20220110")
+            )
         )
         self.assertFalse(
-            DateRange.from_string("20220102:20220106")
-            <= DateRange.from_string("20220103:20220110")
+            DateRange.from_string("20220102:20220106").is_part(
+                DateRange.from_string("20220103:20220110")
+            )
         )
         self.assertFalse(
-            DateRange.from_string("20220102:20220106")
-            > DateRange.from_string("20220103:20220110")
+            DateRange.from_string("20220103:20220110").is_proper_part(
+                DateRange.from_string("20220102:20220106")
+            )
         )
         self.assertFalse(
-            DateRange.from_string("20220102:20220106")
-            >= DateRange.from_string("20220103:20220110")
+            DateRange.from_string("20220103:20220110").is_part(
+                DateRange.from_string("20220102:20220106")
+            )
         )
         self.assertEqual(
             DateRange.from_string("20220103:20220110")
@@ -283,20 +289,19 @@ class DateRangeTest(unittest.TestCase):
     def test_mereology_errors(self):
         dr1 = DateRange(Date("2014-01-01"), Date("2014-01-11"), 2)
         dr2 = DateRange(Date("2014-01-01"), Date("2014-01-05"), 2)
-        with self.assertRaises(ValueError):
-            dr1.overlaps(dr2)
+        self.assertTrue(dr1.overlaps(dr2))
         with self.assertRaises(ValueError):
             dr1.is_adjacent(dr2)
         with self.assertRaises(ValueError):
             dr1.underlaps(dr2)
         with self.assertRaises(ValueError):
-            dr1 < dr2
+            dr1.is_proper_part(dr2)
         with self.assertRaises(ValueError):
-            dr1 <= dr2
+            dr1.is_part(dr2)
         with self.assertRaises(ValueError):
-            dr1 > dr2
+            dr2.is_proper_part(dr1)
         with self.assertRaises(ValueError):
-            dr1 >= dr2
+            dr2.is_part(dr1)
         with self.assertRaises(ValueError):
             dr1 - dr2
         with self.assertRaises(ValueError):

--- a/tests/test_range.py
+++ b/tests/test_range.py
@@ -175,5 +175,93 @@ class DateRangeTest(unittest.TestCase):
 
         self.assertFalse(DateRange.empty().overlaps(DateRange.empty()))
 
+    def test_mereology2(self):
+        self.assertTrue(
+            DateRange.from_string("20220103:20220106").overlaps(
+                DateRange.from_string("20220103:20220110")
+            )
+        )
+        self.assertTrue(
+            DateRange.from_string("20220103:20220106").underlaps(
+                DateRange.from_string("20220103:20220110")
+            )
+        )
+        self.assertTrue(
+            DateRange.from_string("20220103:20220106")
+            < DateRange.from_string("20220103:20220110")
+        )
+        self.assertTrue(
+            DateRange.from_string("20220103:20220106")
+            <= DateRange.from_string("20220103:20220110")
+        )
+        self.assertFalse(
+            DateRange.from_string("20220103:20220106")
+            > DateRange.from_string("20220103:20220110")
+        )
+        self.assertFalse(
+            DateRange.from_string("20220103:20220106")
+            >= DateRange.from_string("20220103:20220110")
+        )
+        self.assertTrue(
+            DateRange.from_string("20220102:20220106").overlaps(
+                DateRange.from_string("20220103:20220110")
+            )
+        )
+        self.assertTrue(
+            DateRange.from_string("20220102:20220106").underlaps(
+                DateRange.from_string("20220103:20220110")
+            )
+        )
+        self.assertFalse(
+            DateRange.from_string("20220102:20220106")
+            < DateRange.from_string("20220103:20220110")
+        )
+        self.assertFalse(
+            DateRange.from_string("20220102:20220106")
+            <= DateRange.from_string("20220103:20220110")
+        )
+        self.assertFalse(
+            DateRange.from_string("20220102:20220106")
+            > DateRange.from_string("20220103:20220110")
+        )
+        self.assertFalse(
+            DateRange.from_string("20220102:20220106")
+            >= DateRange.from_string("20220103:20220110")
+        )
+        self.assertEqual(
+            DateRange.from_string("20220103:20220110")
+            & DateRange.from_string("20211231:20220106"),
+            DateRange.from_string("20220103:20220106"),
+        )
+        self.assertEqual(
+            DateRange.from_string("20220103:20220110")
+            - DateRange.from_string("20211231:20220106"),
+            [DateRange.from_string("20220106:20220110")],
+        )
+        self.assertEqual(
+            (
+                DateRange.from_string("20220103:20220110")
+                & DateRange.from_string("20211231:20220106")
+            )
+            | (
+                DateRange.from_string("20220103:20220110")
+                - DateRange.from_string("20211231:20220106")
+            )[0],
+            DateRange.from_string("20220103:20220110"),
+        )
+        self.assertEqual(
+            DateRange.from_string("20220103:20220110")
+            - DateRange.from_string("20220106:20220113"),
+            [DateRange.from_string("20220103:20220106")],
+        )
+        self.assertEqual(
+            DateRange.from_string("20220103:20220110")
+            - DateRange.from_string("20220104:20220108"),
+            [
+                DateRange.from_string("20220103:20220104"),
+                DateRange.from_string("20220108:20220110"),
+            ],
+        )
+
 
 ################################################################################

--- a/tests/test_range.py
+++ b/tests/test_range.py
@@ -281,21 +281,21 @@ class DateRangeTest(unittest.TestCase):
         dr1 = DateRange(Date("2014-01-01"), Date("2014-01-11"), 2)
         dr2 = DateRange(Date("2014-01-01"), Date("2014-01-05"), 2)
         self.assertTrue(dr1.overlaps(dr2))
-        with self.assertRaises(ValueError):
+        with self.assertRaises(NotImplementedError):
             dr1.is_adjacent(dr2)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(NotImplementedError):
             dr1.underlaps(dr2)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(NotImplementedError):
             dr1.is_proper_part(dr2)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(NotImplementedError):
             dr1.is_part(dr2)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(NotImplementedError):
             dr2.is_proper_part(dr1)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(NotImplementedError):
             dr2.is_part(dr1)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(NotImplementedError):
             dr1 - dr2
-        with self.assertRaises(ValueError):
+        with self.assertRaises(NotImplementedError):
             dr1 | dr2
         with self.assertRaises(ValueError):
             DateRange(Date("2014-01-01"), Date("2014-01-11")).union(

--- a/tests/test_range.py
+++ b/tests/test_range.py
@@ -164,6 +164,8 @@ class DateRangeTest(unittest.TestCase):
             d1 = DateRange.DATE_TYPE.fromordinal(random.randint(0, 1000000))
             d2 = d1 + random.randint(1, 100)
             dr = DateRange(d1, d2)  # non-empty
+            self.assertTrue(DateRange.empty() < dr)
+            self.assertTrue(DateRange.empty() <= dr)
             self.assertFalse(dr < dr)
             self.assertFalse(dr > dr)
             self.assertTrue(dr.overlaps(dr))
@@ -262,6 +264,37 @@ class DateRangeTest(unittest.TestCase):
                 DateRange.from_string("20220108:20220110"),
             ],
         )
+        self.assertEqual(
+            DateRange.from_string("20220103:20220110")
+            - DateRange.from_string("20220101:20220102"),
+            [DateRange.from_string("20220103:20220110")],
+        )
+
+    def test_mereology_errors(self):
+        dr1 = DateRange(Date("2014-01-01"), Date("2014-01-11"), 2)
+        dr2 = DateRange(Date("2014-01-01"), Date("2014-01-05"), 2)
+        with self.assertRaises(ValueError):
+            dr1.overlaps(dr2)
+        with self.assertRaises(ValueError):
+            dr1.is_adjacent(dr2)
+        with self.assertRaises(ValueError):
+            dr1.underlaps(dr2)
+        with self.assertRaises(ValueError):
+            dr1 < dr2
+        with self.assertRaises(ValueError):
+            dr1 <= dr2
+        with self.assertRaises(ValueError):
+            dr1 > dr2
+        with self.assertRaises(ValueError):
+            dr1 >= dr2
+        with self.assertRaises(ValueError):
+            dr1 - dr2
+        with self.assertRaises(ValueError):
+            dr1 | dr2
+        with self.assertRaises(ValueError):
+            DateRange(Date("2014-01-01"), Date("2014-01-11")).union(
+                DateRange(Date("2014-01-12"), Date("2014-01-16"))
+            )
 
 
 ################################################################################

--- a/tests/test_range.py
+++ b/tests/test_range.py
@@ -269,6 +269,16 @@ class DateRangeTest(unittest.TestCase):
             - DateRange.from_string("20220101:20220102"),
             [DateRange.from_string("20220103:20220110")],
         )
+        self.assertEqual(
+            DateRange.from_string("20220105:20220110")
+            - DateRange.from_string("20220101:20220107"),
+            [DateRange(20220107, 20220110)],
+        )
+        self.assertEqual(
+            DateRange.from_string("20220101:20220107")
+            - DateRange.from_string("20220105:20220110"),
+            [DateRange(20220101, 20220105)],
+        )
 
     def test_mereology_errors(self):
         dr1 = DateRange(Date("2014-01-01"), Date("2014-01-11"), 2)

--- a/tests/test_range.py
+++ b/tests/test_range.py
@@ -151,6 +151,7 @@ class DateRangeTest(unittest.TestCase):
             self.assertEqual(type(r1), type(r2))
 
     def test_mereology(self):
+        random.seed(42)
         for _ in range(1000):
             d1 = DateRange.DATE_TYPE.fromordinal(random.randint(0, 1000000))
             d2 = d1 + random.randint(1, 100)

--- a/tests/test_range.py
+++ b/tests/test_range.py
@@ -6,9 +6,7 @@ import unittest
 import math
 import pickle
 import random
-
 from yyyymmdd import Date, DateRange
-
 from .test_date import TEST_DATES
 
 ################################################################################

--- a/tests/test_range.py
+++ b/tests/test_range.py
@@ -26,7 +26,6 @@ TEST_RANGES = dict(
 
 ################################################################################
 
-
 class DateRangeTest(unittest.TestCase):
     """
     Tests DateRange class.
@@ -67,14 +66,10 @@ class DateRangeTest(unittest.TestCase):
                         self.assertEqual(d in r, d in datelist)
                         self.assertEqual(d.as_datetime_date() in r, d in datelist)
                         self.assertEqual(r.count(d), datelist.count(d))
-                        self.assertEqual(
-                            r.count(d.as_datetime_date()), datelist.count(d)
-                        )
+                        self.assertEqual(r.count(d.as_datetime_date()), datelist.count(d))
                         if d in datelist:
                             self.assertEqual(r.index(d), datelist.index(d))
-                            self.assertEqual(
-                                r.index(d.as_datetime_date()), datelist.index(d)
-                            )
+                            self.assertEqual(r.index(d.as_datetime_date()), datelist.index(d))
                         else:
                             self.assertRaises(ValueError, r.index, d)
                             self.assertRaises(ValueError, r.index, d.as_datetime_date())
@@ -94,7 +89,7 @@ class DateRangeTest(unittest.TestCase):
         r = DateRange(int(str(start)), int(str(stop)))
         self.assertEqual(r0, r)
         # relative to today
-        r = DateRange("-10", "+10")
+        r = DateRange('-10', '+10')
         self.assertEqual(r, DateRange(Date.today() - 10, Date.today() + 10))
 
     def test_from_string(self):
@@ -102,27 +97,25 @@ class DateRangeTest(unittest.TestCase):
         r = DateRange(D1, D1 + 1)
         self.assertEqual(r, DateRange.from_string(str(D1)))
         self.assertEqual(r, DateRange.from_string(str(r)))
-        self.assertEqual(r, DateRange.from_string(D1.strftime("%Y-%m-%d")))
+        self.assertEqual(r, DateRange.from_string(D1.strftime('%Y-%m-%d')))
         # start and stop
         r = DateRange(D1, D1 + 100)
         self.assertEqual(r, DateRange.from_string(str(r)))
-        self.assertEqual(r, DateRange.from_string("%s:%s" % (r.start, r.stop)))
+        self.assertEqual(r, DateRange.from_string('%s:%s' % (r.start, r.stop)))
         # start, stop and step
         r = DateRange(D1, D1 + 100, 7)
         self.assertEqual(r, DateRange.from_string(str(r)))
-        self.assertEqual(
-            r, DateRange.from_string("%s:%s:%s" % (r.start, r.stop, r.step))
-        )
+        self.assertEqual(r, DateRange.from_string('%s:%s:%s' % (r.start, r.stop, r.step)))
         # relatives and negatives
-        r1 = DateRange("+30", -50, -2)
-        r2 = DateRange.from_string("+30:-50:-2")
+        r1 = DateRange('+30', -50, -2)
+        r2 = DateRange.from_string('+30:-50:-2')
         self.assertEqual(r1, r2)
         self.assertEqual(len(r2), 40)
         # aliases
-        self.assertEqual(DateRange.from_string("NONE"), DateRange.empty())
-        self.assertEqual(DateRange.from_string("EMPTY"), DateRange.empty())
-        self.assertEqual(DateRange.from_string("ALL"), DateRange.full())
-        self.assertEqual(DateRange.from_string("FULL"), DateRange.full())
+        self.assertEqual(DateRange.from_string('NONE'), DateRange.empty())
+        self.assertEqual(DateRange.from_string('EMPTY'), DateRange.empty())
+        self.assertEqual(DateRange.from_string('ALL'), DateRange.full())
+        self.assertEqual(DateRange.from_string('FULL'), DateRange.full())
         for r in [DateRange.empty(), DateRange.full()]:
             self.assertEqual(r, DateRange.from_string(str(r)))
 

--- a/yyyymmdd/range.py
+++ b/yyyymmdd/range.py
@@ -538,13 +538,13 @@ class DateRange(object):
             part2 = DateRange(
                 self._o2d(other._ordrange.stop), self._o2d(self._ordrange.stop)
             )
-            if bool(part1):
-                if bool(part2):
+            if part1:
+                if part2:
                     return [part1, part2]
                 else:
                     return [part1]
             else:
-                if bool(part2):
+                if part2:
                     return [part2]
                 return [DateRange.empty()]
         else:

--- a/yyyymmdd/range.py
+++ b/yyyymmdd/range.py
@@ -363,8 +363,8 @@ class DateRange(object):
         Mereological function check: This range and `other` must have step=1.
         """
         if self.step != 1 or other.step != 1:
-            raise ValueError(
-                "Mereological methods are undefined for ranges with steps != 1: %r & %r"
+            raise NotImplementedError(
+                "Mereological methods are currently undefined for ranges with steps != 1: %r & %r"
                 % (self, other)
             )
 

--- a/yyyymmdd/range.py
+++ b/yyyymmdd/range.py
@@ -3,11 +3,12 @@ The ``DateRange`` class.
 """
 
 from .date import Date
-from .misc import classproperty, egcd as _egcd
-
+from .misc import classproperty
+from .misc import egcd as _egcd
 
 ################################################################################
 # The DateRange class
+
 
 class DateRange(object):
     """
@@ -23,10 +24,10 @@ class DateRange(object):
     """
 
     DATE_TYPE = Date
-    DELIM = ':'
-    OTHER_SIDE_MARKER = '%'
-    EMPTY_RANGE_STRING = 'NONE'
-    FULL_RANGE_STRING = 'ALL'
+    DELIM = ":"
+    OTHER_SIDE_MARKER = "%"
+    EMPTY_RANGE_STRING = "NONE"
+    FULL_RANGE_STRING = "ALL"
 
     # ===============================================================================================
     # ctor
@@ -110,7 +111,7 @@ class DateRange(object):
         try:
             return self._ordrange.index(ordinal)
         except ValueError:
-            raise ValueError('%r is not in range' % date) from None
+            raise ValueError("%r is not in range" % date) from None
 
     def count(self, date):
         """ Same as ``range.count``. """
@@ -139,10 +140,17 @@ class DateRange(object):
     # str and repr
     # ===========================================================================
 
-    def to_string(self,
-                  opening_bracket='[', closing_bracket=')', *,
-                  date_format=None, delim=None, step_delim=None, include_step=None,
-                  empty_range_string=EMPTY_RANGE_STRING):
+    def to_string(
+        self,
+        opening_bracket="[",
+        closing_bracket=")",
+        *,
+        date_format=None,
+        delim=None,
+        step_delim=None,
+        include_step=None,
+        empty_range_string=EMPTY_RANGE_STRING
+    ):
 
         if empty_range_string is not None and not self:
             return empty_range_string
@@ -165,7 +173,7 @@ class DateRange(object):
             tokens.extend([step_delim, str(self.step)])
 
         tokens.append(closing_bracket)
-        return ''.join(tokens)
+        return "".join(tokens)
 
     def __str__(self):
         return self.to_string()
@@ -174,7 +182,7 @@ class DateRange(object):
         tokens = [self.start, self.stop]
         if self.step != 1:
             tokens.append(self.step)
-        return '%s(%s)' % (type(self).__name__, ', '.join([str(x) for x in tokens]))
+        return "%s(%s)" % (type(self).__name__, ", ".join([str(x) for x in tokens]))
 
     # ===========================================================================
     # from string
@@ -198,13 +206,13 @@ class DateRange(object):
         DateRange(20120704, 20120706)
         """
 
-        if s in (cls.FULL_RANGE_STRING, 'FULL'):
+        if s in (cls.FULL_RANGE_STRING, "FULL"):
             return cls.full()
-        if s in (cls.EMPTY_RANGE_STRING, 'EMPTY'):
+        if s in (cls.EMPTY_RANGE_STRING, "EMPTY"):
             return cls.empty()
 
         # remove brackets:
-        if s.startswith('[') and s.endswith(')'):
+        if s.startswith("[") and s.endswith(")"):
             s = s[1:-1]
 
         # split to parts:
@@ -219,10 +227,10 @@ class DateRange(object):
             # start and stop, and possibly step
 
             def has_marker(p, m=cls.OTHER_SIDE_MARKER):
-                return (p == m) or (p.startswith(m) and p[len(m)] in '+-')
+                return (p == m) or (p.startswith(m) and p[len(m)] in "+-")
 
             def relative_to(part, rel_to, m=cls.OTHER_SIDE_MARKER):
-                offset_str = part[len(cls.OTHER_SIDE_MARKER):]
+                offset_str = part[len(cls.OTHER_SIDE_MARKER) :]
                 if offset_str:
                     # e.g. '%+10'
                     offset = int(offset_str)
@@ -249,7 +257,7 @@ class DateRange(object):
             return cls(d1, d2, step)
 
         else:
-            raise ValueError('Invalid %s string: %r' % (cls.__name__, s))
+            raise ValueError("Invalid %s string: %r" % (cls.__name__, s))
 
     # ===========================================================================
     # misc
@@ -258,9 +266,9 @@ class DateRange(object):
     def replace(self, *, start=None, stop=None, step=None):
         """ Create a range like self, with different parts (start/stop/step) """
         kwargs = {}
-        kwargs['start'] = start if start is not None else self.start
-        kwargs['stop'] = stop if stop is not None else self.stop
-        kwargs['step'] = step if step is not None else self.step
+        kwargs["start"] = start if start is not None else self.start
+        kwargs["stop"] = stop if stop is not None else self.stop
+        kwargs["step"] = step if step is not None else self.step
         return type(self)(**kwargs)
 
     @classproperty
@@ -297,7 +305,7 @@ class DateRange(object):
         """
         if len(self) == 1:
             return str(self[0])
-        return self.to_string('', '')
+        return self.to_string("", "")
 
     # ===========================================================================
     # Intersection
@@ -316,18 +324,34 @@ class DateRange(object):
 
         # check steps have the same sign
         if (self.step > 0) != (other.step > 0):
-            raise ValueError('Intersection is undefined for steps with opposite signs: %r & %r' % (
-                self, other))
+            raise ValueError(
+                "Intersection is undefined for steps with opposite signs: %r & %r"
+                % (self, other)
+            )
 
         # more helpers
 
         def stop_min(x, y):
-            return None if x is None and y is None \
-                else x if y is None else y if x is None else min(x, y)
+            return (
+                None
+                if x is None and y is None
+                else x
+                if y is None
+                else y
+                if x is None
+                else min(x, y)
+            )
 
         def stop_max_inv(x, y):
-            return None if x is None and y is None \
-                else x if y is None else y if x is None else max(x, y)
+            return (
+                None
+                if x is None and y is None
+                else x
+                if y is None
+                else y
+                if x is None
+                else max(x, y)
+            )
 
         # return empty Range if either ranges is empty
         empty = self.empty()
@@ -335,10 +359,17 @@ class DateRange(object):
             return empty()
 
         # both directions are the same
-        step0, step1, sign, offset = (abs(self.step), abs(other.step),
-                                      (self.step > 0) - (self.step < 0), other.start - self.start)
+        step0, step1, sign, offset = (
+            abs(self.step),
+            abs(other.step),
+            (self.step > 0) - (self.step < 0),
+            other.start - self.start,
+        )
         gcd, x, y = _egcd(step0, step1)
-        interval0, interval1 = step0 // gcd, step1 // gcd  # calculate the coprime intervals
+        interval0, interval1 = (
+            step0 // gcd,
+            step1 // gcd,
+        )  # calculate the coprime intervals
         step = interval0 * interval1 * gcd * sign
         if offset % gcd != 0:  # return empty result if offset not alligned on gcd
             return empty()
@@ -351,8 +382,173 @@ class DateRange(object):
             gap = offset - crt
             filler = gap if 0 == gap % step else (gap // step + 1) * step
         start = self.start + crt + filler
-        stop = stop_min(self.stop, other.stop) if sign > 0 else stop_max_inv(self.stop, other.stop)
+        stop = (
+            stop_min(self.stop, other.stop)
+            if sign > 0
+            else stop_max_inv(self.stop, other.stop)
+        )
         return type(self)(start, stop, step)
+
+    # ===========================================================================
+    # mereological part structure
+    # ===========================================================================
+
+    def __lt__(self, other):
+        return self.is_proper_part(other)
+
+    def __gt__(self, other):
+        return other.is_proper_part(self)
+
+    def __le__(self, other):
+        if self.step != 1 or other.step != 1:
+            raise ValueError(
+                "Mereological methods are undefined for ranges with steps != 1: %r & %r"
+                % (self, other)
+            )
+        if not bool(self._ordrange):
+            return True
+        return (other._ordrange.start <= self._ordrange.start) and (
+            self._ordrange.stop <= other._ordrange.stop
+        )
+
+    def __ge__(self, other):
+        return other <= self
+
+    def is_adjacent(self, other):
+        """
+        Tests whether this DateRange is adjacent to (externally connected)
+        to the given DateRange other.
+        """
+        if self.step != 1 or other.step != 1:
+            raise ValueError(
+                "Mereological methods are undefined for ranges with steps != 1: %r & %r"
+                % (self, other)
+            )
+        return (self._ordrange.stop == other._ordrange.start) or (
+            other._ordrange.stop == self._ordrange.start
+        )
+
+    def is_proper_part(self, other):
+        """
+        Tests whether this DateRange is a proper part of (is fully
+        contained in) the given DateRange other.
+
+        X is a proper part of Y if X is a part of Y and Y is not a part of X.
+        """
+        if self.step != 1 or other.step != 1:
+            raise ValueError(
+                "Mereological methods are undefined for ranges with steps != 1: %r & %r"
+                % (self, other)
+            )
+        if not bool(self._ordrange):
+            return True
+        return (
+            (other._ordrange.start <= self._ordrange.start)
+            and (self._ordrange.stop <= other._ordrange.stop)
+            and (self._ordrange != other._ordrange)
+        )
+
+    def overlaps(self, other):
+        """
+        Tests whether this DateRange overlaps with the given DateRange other.
+
+        X and Y overlap if there is a part of X that is also a part of Y.
+        """
+        if self.step != 1 or other.step != 1:
+            raise ValueError(
+                "Mereological methods are undefined for ranges with steps != 1: %r & %r"
+                % (self, other)
+            )
+        return (bool(self._ordrange) and bool(other._ordrange)) and (
+            (other._ordrange.start <= self._ordrange.start < other._ordrange.stop)
+            or (self._ordrange.start <= other._ordrange.start < self._ordrange.stop)
+        )
+
+    def underlaps(self, other):
+        """
+        Finds the underlap of this DateRange and the given DateRange other.
+
+        The X and Y underlap if X and Y overlap or are adjacent.
+        """
+        if self.step != 1 or other.step != 1:
+            raise ValueError(
+                "Mereological methods are undefined for ranges with steps != 1: %r & %r"
+                % (self, other)
+            )
+        return self.is_adjacent(other) or self.overlaps(other)
+
+    def __or__(self, other):
+        return self.union(other)
+
+    def union(self, other):
+        """
+        Computes the union of this DateRange and the given DateRange other.
+
+        The union of X and Y is only defined if X and Y underlap.
+        """
+        if self.step != 1 or other.step != 1:
+            raise ValueError(
+                "Mereological methods are undefined for ranges with steps != 1: %r & %r"
+                % (self, other)
+            )
+        if not self.underlaps(other):
+            raise ValueError(
+                "DateRange union is undefined for ranges that are not adjacent and do not overlap: %r & %r"
+                % (self, other)
+            )
+        return DateRange(
+            self._o2d(min(self._ordrange.start, other._ordrange.start)),
+            self._o2d(max(self._ordrange.stop, other._ordrange.stop)),
+        )
+
+    def __sub__(self, other):
+        return self.difference(other)
+
+    def difference(self, other):
+        """
+        Computes the dates from this DateRange less the dates in the given
+        DateRange other.
+
+        This method returns a list, because the difference can result
+        up to two contiguous date ranges.
+        """
+        if self.step != 1 or other.step != 1:
+            raise ValueError(
+                "Mereological methods are undefined for ranges with steps != 1: %r & %r"
+                % (self, other)
+            )
+        # ***A***
+        #   ***B***
+        # gives:
+        # **
+        #
+        #   ***A***
+        # ***B***
+        # gives:
+        #        **
+        #
+        # *****A*****
+        #   **B**
+        # gives:
+        # **     ****
+        if self.overlaps(other):
+            part1 = DateRange(
+                self._o2d(self._ordrange.start), self._o2d(other._ordrange.start)
+            )
+            part2 = DateRange(
+                self._o2d(other._ordrange.stop), self._o2d(self._ordrange.stop)
+            )
+            if bool(part1):
+                if bool(part2):
+                    return [part1, part2]
+                else:
+                    return [part1]
+            else:
+                if bool(part2):
+                    return [part2]
+                return [DateRange.empty()]
+        else:
+            return self
 
     # ===========================================================================
     # privates

--- a/yyyymmdd/range.py
+++ b/yyyymmdd/range.py
@@ -336,17 +336,10 @@ class DateRange(object):
             return empty
 
         # both directions are the same
-        step0, step1, sign, offset = (
-            abs(self.step),
-            abs(other.step),
-            (self.step > 0) - (self.step < 0),
-            other.start - self.start,
-        )
+        step0, step1, sign, offset = (abs(self.step), abs(other.step),
+                                      (self.step > 0) - (self.step < 0), other.start - self.start)
         gcd, x, y = _egcd(step0, step1)
-        interval0, interval1 = (
-            step0 // gcd,
-            step1 // gcd,
-        )  # calculate the coprime intervals
+        interval0, interval1 = step0 // gcd, step1 // gcd  # calculate the coprime intervals
         step = interval0 * interval1 * gcd * sign
         if offset % gcd != 0:  # return empty result if offset not alligned on gcd
             return empty
@@ -359,11 +352,7 @@ class DateRange(object):
             gap = offset - crt
             filler = gap if 0 == gap % step else (gap // step + 1) * step
         start = self.start + crt + filler
-        stop = (
-            stop_min(self.stop, other.stop)
-            if sign > 0
-            else stop_max_inv(self.stop, other.stop)
-        )
+        stop = stop_min(self.stop, other.stop) if sign > 0 else stop_max_inv(self.stop, other.stop)
         return type(self)(start, stop, step)
 
     # ===========================================================================

--- a/yyyymmdd/range.py
+++ b/yyyymmdd/range.py
@@ -9,7 +9,6 @@ from .misc import classproperty, egcd as _egcd
 ################################################################################
 # The DateRange class
 
-
 class DateRange(object):
     """
     A `range <https://docs.python.org/3.8/library/functions.html#func-range>`_ -like type, whose

--- a/yyyymmdd/range.py
+++ b/yyyymmdd/range.py
@@ -3,8 +3,8 @@ The ``DateRange`` class.
 """
 
 from .date import Date
-from .misc import classproperty
-from .misc import egcd as _egcd
+from .misc import classproperty, egcd as _egcd
+
 
 ################################################################################
 # The DateRange class
@@ -24,10 +24,10 @@ class DateRange(object):
     """
 
     DATE_TYPE = Date
-    DELIM = ":"
-    OTHER_SIDE_MARKER = "%"
-    EMPTY_RANGE_STRING = "NONE"
-    FULL_RANGE_STRING = "ALL"
+    DELIM = ':'
+    OTHER_SIDE_MARKER = '%'
+    EMPTY_RANGE_STRING = 'NONE'
+    FULL_RANGE_STRING = 'ALL'
 
     # ===============================================================================================
     # ctor
@@ -111,7 +111,7 @@ class DateRange(object):
         try:
             return self._ordrange.index(ordinal)
         except ValueError:
-            raise ValueError("%r is not in range" % date) from None
+            raise ValueError('%r is not in range' % date) from None
 
     def count(self, date):
         """ Same as ``range.count``. """
@@ -140,17 +140,10 @@ class DateRange(object):
     # str and repr
     # ===========================================================================
 
-    def to_string(
-        self,
-        opening_bracket="[",
-        closing_bracket=")",
-        *,
-        date_format=None,
-        delim=None,
-        step_delim=None,
-        include_step=None,
-        empty_range_string=EMPTY_RANGE_STRING
-    ):
+    def to_string(self,
+                  opening_bracket='[', closing_bracket=')', *,
+                  date_format=None, delim=None, step_delim=None, include_step=None,
+                  empty_range_string=EMPTY_RANGE_STRING):
 
         if empty_range_string is not None and not self:
             return empty_range_string
@@ -173,7 +166,7 @@ class DateRange(object):
             tokens.extend([step_delim, str(self.step)])
 
         tokens.append(closing_bracket)
-        return "".join(tokens)
+        return ''.join(tokens)
 
     def __str__(self):
         return self.to_string()
@@ -182,7 +175,7 @@ class DateRange(object):
         tokens = [self.start, self.stop]
         if self.step != 1:
             tokens.append(self.step)
-        return "%s(%s)" % (type(self).__name__, ", ".join([str(x) for x in tokens]))
+        return '%s(%s)' % (type(self).__name__, ', '.join([str(x) for x in tokens]))
 
     # ===========================================================================
     # from string
@@ -206,13 +199,13 @@ class DateRange(object):
         DateRange(20120704, 20120706)
         """
 
-        if s in (cls.FULL_RANGE_STRING, "FULL"):
+        if s in (cls.FULL_RANGE_STRING, 'FULL'):
             return cls.full()
-        if s in (cls.EMPTY_RANGE_STRING, "EMPTY"):
+        if s in (cls.EMPTY_RANGE_STRING, 'EMPTY'):
             return cls.empty()
 
         # remove brackets:
-        if s.startswith("[") and s.endswith(")"):
+        if s.startswith('[') and s.endswith(')'):
             s = s[1:-1]
 
         # split to parts:
@@ -227,10 +220,10 @@ class DateRange(object):
             # start and stop, and possibly step
 
             def has_marker(p, m=cls.OTHER_SIDE_MARKER):
-                return (p == m) or (p.startswith(m) and p[len(m)] in "+-")
+                return (p == m) or (p.startswith(m) and p[len(m)] in '+-')
 
             def relative_to(part, rel_to, m=cls.OTHER_SIDE_MARKER):
-                offset_str = part[len(cls.OTHER_SIDE_MARKER) :]
+                offset_str = part[len(cls.OTHER_SIDE_MARKER):]
                 if offset_str:
                     # e.g. '%+10'
                     offset = int(offset_str)
@@ -257,7 +250,7 @@ class DateRange(object):
             return cls(d1, d2, step)
 
         else:
-            raise ValueError("Invalid %s string: %r" % (cls.__name__, s))
+            raise ValueError('Invalid %s string: %r' % (cls.__name__, s))
 
     # ===========================================================================
     # misc
@@ -266,9 +259,9 @@ class DateRange(object):
     def replace(self, *, start=None, stop=None, step=None):
         """ Create a range like self, with different parts (start/stop/step) """
         kwargs = {}
-        kwargs["start"] = start if start is not None else self.start
-        kwargs["stop"] = stop if stop is not None else self.stop
-        kwargs["step"] = step if step is not None else self.step
+        kwargs['start'] = start if start is not None else self.start
+        kwargs['stop'] = stop if stop is not None else self.stop
+        kwargs['step'] = step if step is not None else self.step
         return type(self)(**kwargs)
 
     @classproperty
@@ -305,7 +298,7 @@ class DateRange(object):
         """
         if len(self) == 1:
             return str(self[0])
-        return self.to_string("", "")
+        return self.to_string('', '')
 
     # ===========================================================================
     # Intersection
@@ -324,34 +317,18 @@ class DateRange(object):
 
         # check steps have the same sign
         if (self.step > 0) != (other.step > 0):
-            raise ValueError(
-                "Intersection is undefined for steps with opposite signs: %r & %r"
-                % (self, other)
-            )
+            raise ValueError('Intersection is undefined for steps with opposite signs: %r & %r' % (
+                self, other))
 
         # more helpers
 
         def stop_min(x, y):
-            return (
-                None
-                if x is None and y is None
-                else x
-                if y is None
-                else y
-                if x is None
-                else min(x, y)
-            )
+            return None if x is None and y is None \
+                else x if y is None else y if x is None else min(x, y)
 
         def stop_max_inv(x, y):
-            return (
-                None
-                if x is None and y is None
-                else x
-                if y is None
-                else y
-                if x is None
-                else max(x, y)
-            )
+            return None if x is None and y is None \
+                else x if y is None else y if x is None else max(x, y)
 
         # return empty Range if either ranges is empty
         empty = self.empty()

--- a/yyyymmdd/range.py
+++ b/yyyymmdd/range.py
@@ -548,7 +548,7 @@ class DateRange(object):
                     return [part2]
                 return [DateRange.empty()]
         else:
-            return self
+            return [self]
 
     # ===========================================================================
     # privates


### PR DESCRIPTION
Hi @shx2,

First of all, thank you for this sweet library!  Really nicely done.

I'm sending a pull request which may or may not interest you, adding a bunch of methods to the DateRange type.

I've been looking for a library to perform "arithmetic" on date ranges (figuring out which date ranges overlap with each other, computing the set unions, intersections and differences of their constituent days, etc.) and so far I haven't found anything.  On the other hand, I did come across your `yyyymmdd` module, which is pretty neat.  So I just decided to add the date range operations into `yyyymmdd`, as it solves my particular problem for now.  I'm opening this PR here in case you'd like to merge these changes back.

The basic idea is that date range objects form a kind of [mereology](https://en.wikipedia.org/wiki/Mereology) or lattice structure: date ranges can be parts of other date ranges, or they can overlap, or be "adjacent" to each other. For instance, Monday to Friday (inclusive) is adjacent to the weekend (inclusive), but doesn't overlap it.  The "underlap" relation means either overlapping or adjacency.  In cases where two date ranges overlap, it's meaningful to define the intersection (which you already have), as well as the difference.  In cases where two date ranges underlap, it's also meaningful to define the union.

```
# jan 3 to jan 6 is not a part of jan 1 to jan 5
>>> DateRange(20000101, 20000105) >= DateRange(20000103, 20000106)
False
# jan 3 to jan 5 IS a part of jan 1 to jan 5
>>> DateRange(20000101, 20000105) >= DateRange(20000103, 20000105)  
True
# jan 1 to jan 5  overlaps with jan 3 to jan 6
>>> DateRange(20000101, 20000105).overlaps(DateRange(20000103, 20000106))
True
# jan 1 to jan 5  "minus" jan 3 to jan 6 is jan 1 to jan 3
>>> DateRange(20000101, 20000105) - DateRange(20000103, 20000106)  
[DateRange(20000101, 20000103)]
# jan 1 to jan 5  "union" jan 3 to jan 6 is jan 1 to jan 6
>>> DateRange(20000101, 20000105) | DateRange(20000103, 20000106)  
DateRange(20000101, 20000106)
```

I've added test cases to cover all the new code.

There are some quirks to this stuff.  The new methods don't work when `step` is not 1; I think it makes sense to talk about the intersection of two date ranges with non-unit stepsize, as you've done, but not to talk about the union or difference.  Another weirdness is that the difference operator returns a list, because the difference can be either empty, non-empty, or two non-empty date ranges:

```
# jan 1 to jan 10 "minus" jan 3 to jan 6 is jan 1 to jan 3 AND jan 6 to jan 10
>>> DateRange(20000101, 20000110) - DateRange(20000103, 20000106)  
[DateRange(20000101, 20000103), DateRange(20000106, 20000110)]
```

OK, that's about it.  Let me know if you're interested.  I'd be happy to copy-paste some of this stuff into the README if you'd like.

Best, Will